### PR TITLE
updating library path for text/unicode

### DIFF
--- a/feature_test.go
+++ b/feature_test.go
@@ -5,8 +5,9 @@
 package simhash
 
 import (
-	"code.google.com/p/go.text/unicode/norm"
 	"testing"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 func TestNewFeature(t *testing.T) {

--- a/simhash.go
+++ b/simhash.go
@@ -12,9 +12,10 @@ package simhash
 
 import (
 	"bytes"
-	"code.google.com/p/go.text/unicode/norm"
 	"hash/fnv"
 	"regexp"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 type Vector [64]int


### PR DESCRIPTION
Hi, 

I'm looking to use this package in a current project and in getting set up I noticed the path to `text/unicode` references the old mercurial based locations. Since Go has moved from there I've updated the paths. 

I hope this is ok with you. 

Thanks
Nathan
